### PR TITLE
Add testimonials slider and page

### DIFF
--- a/meta/testimonials.yml
+++ b/meta/testimonials.yml
@@ -1,0 +1,11 @@
+
+testimonials:
+  - id: 1
+    name: Jane Doe
+    text: "Jemma's Nutritional Coaching transformed my relationship with food. I've never felt healthier!"
+  - id: 2
+    name: John Smith
+    text: "The personalized meal plans were a game-changer for my fitness goals."
+  - id: 3
+    name: Emily Brown
+    text: "The group workshops were both informative and fun. Highly recommended!"

--- a/src/components/TestimonialSlider.tsx
+++ b/src/components/TestimonialSlider.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { testimonials } from '../lib/testimonials'
+
+export default function TestimonialSlider() {
+  const [currentIndex, setCurrentIndex] = useState(0)
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCurrentIndex((prevIndex) => (prevIndex + 1) % testimonials.length)
+    }, 5000)
+    return () => clearInterval(timer)
+  }, [])
+
+  const goToPrevious = () => {
+    setCurrentIndex((prevIndex) => (prevIndex - 1 + testimonials.length) % testimonials.length)
+  }
+
+  const goToNext = () => {
+    setCurrentIndex((prevIndex) => (prevIndex + 1) % testimonials.length)
+  }
+
+  return (
+    <div className="relative max-w-2xl mx-auto">
+      <div className="overflow-hidden">
+        <div className="flex transition-transform duration-300 ease-in-out" style={{ transform: `translateX(-${currentIndex * 100}%)` }}>
+          {testimonials.map((testimonial) => (
+            <div key={testimonial.id} className="w-full flex-shrink-0 px-4">
+              <blockquote className="text-center">
+                <p className="text-lg font-medium text-primary-foreground mb-4">"{testimonial.text}"</p>
+                <cite className="text-accent-terra font-semibold">- {testimonial.name}</cite>
+              </blockquote>
+            </div>
+          ))}
+        </div>
+      </div>
+      <button onClick={goToPrevious} className="absolute top-1/2 left-0 transform -translate-y-1/2 bg-white rounded-full p-2 shadow-md">
+        <ChevronLeft className="w-6 h-6 text-accent-sage" />
+      </button>
+      <button onClick={goToNext} className="absolute top-1/2 right-0 transform -translate-y-1/2 bg-white rounded-full p-2 shadow-md">
+        <ChevronRight className="w-6 h-6 text-accent-sage" />
+      </button>
+    </div>
+  )
+}

--- a/src/components/TestimonialsSection.tsx
+++ b/src/components/TestimonialsSection.tsx
@@ -1,0 +1,19 @@
+import { testimonials } from "../lib/testimonials";
+
+export default function TestimonialsSection() {
+  return (
+    <section className="my-12 bg-secondary py-12">
+      <div className="container mx-auto">
+        <h2 className="text-3xl font-bold mb-6 text-center text-secondary-foreground">What Our Clients Say</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          {testimonials.map((testimonial, index) => (
+            <div key={testimonial.id} className="bg-primary p-6 rounded-lg shadow-md">
+              <p className="text-primary-foreground mb-4">"{testimonial.text}"</p>
+              <p className={`font-semibold text-accent-${index === 0 ? 'lime' : index === 1 ? 'raspberry' : 'orange'}`}>- {testimonial.name}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/testimonials.ts
+++ b/src/lib/testimonials.ts
@@ -1,0 +1,9 @@
+import testimonialsData from "../../meta/testimonials.yml";
+
+export type Testimonial = {
+  readonly id: number;
+  readonly name: string;
+  readonly text: string;
+};
+
+export const testimonials: Testimonial[] = testimonialsData.testimonials;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,6 +3,7 @@ import BasicMeta from "../components/meta/BasicMeta";
 import OpenGraphMeta from "../components/meta/OpenGraphMeta";
 import TwitterCardMeta from "../components/meta/TwitterCardMeta";
 import { SocialList } from "../components/SocialList";
+import TestimonialSlider from "../components/TestimonialSlider";
 import Link from "next/link";
 import { GetStaticProps } from "next";
 import { fetchPostContent, PostContent } from "../lib/posts";
@@ -45,6 +46,8 @@ export default function Index({ recentPosts }: Props) {
               ))}
             </ul>
           </section>
+
+          <TestimonialSlider />
 
           {/*<SocialList /> - Commented to prevent displaying in main page*/}
         </div>

--- a/src/pages/testimonials.tsx
+++ b/src/pages/testimonials.tsx
@@ -1,0 +1,23 @@
+import Layout from "../components/Layout";
+import BasicMeta from "../components/meta/BasicMeta";
+import OpenGraphMeta from "../components/meta/OpenGraphMeta";
+import TwitterCardMeta from "../components/meta/TwitterCardMeta";
+import TestimonialsSection from "../components/TestimonialsSection";
+import TestimonialSlider from "../components/TestimonialSlider";
+
+export default function TestimonialsPage() {
+  const url = "/testimonials";
+  const title = "Testimonials";
+  return (
+    <Layout>
+      <BasicMeta url={url} title={title} />
+      <OpenGraphMeta url={url} title={title} />
+      <TwitterCardMeta url={url} title={title} />
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold mb-8 text-center">Testimonials</h1>
+        <TestimonialSlider />
+        <TestimonialsSection />
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- centralize testimonial content in `meta/testimonials.yml`
- expose testimonial data via `src/lib/testimonials.ts`
- create `TestimonialsSection` and `TestimonialSlider` components
- add a dedicated testimonials page
- show testimonial slider on the home page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: numerous type errors)*

------
https://chatgpt.com/codex/tasks/task_e_684440572ae88330a67b56697461591c