### PR TITLE
Implement hero and service sections

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,15 +1,28 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/router'
 
 export default function ContactForm() {
-  const [formData, setFormData] = useState({ name: '', email: '', message: '' })
+  const router = useRouter()
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    message: '',
+    service: '',
+  })
+
+  useEffect(() => {
+    if (typeof router.query.service === 'string') {
+      setFormData(prev => ({ ...prev, service: router.query.service as string }))
+    }
+  }, [router.query.service])
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     console.log('Form submitted:', formData)
     alert('Thank you for your message! We will get back to you soon.')
-    setFormData({ name: '', email: '', message: '' })
+    setFormData({ name: '', email: '', message: '', service: formData.service })
   }
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -21,6 +34,7 @@ export default function ContactForm() {
     <section className="my-12">
       <h2 className="text-3xl font-bold mb-6 text-center">Contact Us</h2>
       <form onSubmit={handleSubmit} className="max-w-md mx-auto">
+        <input type="hidden" name="service" value={formData.service} />
         <div className="mb-4">
           <label htmlFor="name" className="block text-foreground font-bold mb-2">Name</label>
           <input

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -5,8 +5,9 @@ import Breadcrumb from "./Breadcrumb";
 
 type Props = {
   children: React.ReactNode;
+  showBreadcrumb?: boolean;
 };
-export default function Layout({ children }: Props) {
+export default function Layout({ children, showBreadcrumb = true }: Props) {
   return (
     <div className="root">
       <Head>
@@ -17,7 +18,7 @@ export default function Layout({ children }: Props) {
         <meta name="theme-color" content="#fff" />
       </Head>
       <Header />
-      <Breadcrumb />
+      {showBreadcrumb && <Breadcrumb />}
       <main>{children}</main>
       <Footer />
       <style jsx>
@@ -31,6 +32,7 @@ export default function Layout({ children }: Props) {
           main {
             flex: 1 0 auto;
             display: flex;
+            flex-direction: column;
           }
         `}
       </style>

--- a/src/components/WorkWithMeSection.tsx
+++ b/src/components/WorkWithMeSection.tsx
@@ -1,0 +1,88 @@
+import Link from 'next/link'
+import { Salad, Dumbbell, Users } from 'lucide-react'
+
+const services = [
+  {
+    id: 1,
+    name: 'Personalized Meal Planning',
+    description: 'Customized meal plans tailored to your nutritional needs and goals.',
+    icon: Salad,
+  },
+  {
+    id: 2,
+    name: 'One-on-One Coaching',
+    description: 'Individual coaching sessions to guide you through your nutritional journey.',
+    icon: Dumbbell,
+  },
+  {
+    id: 3,
+    name: 'Group Workshops',
+    description: 'Interactive group sessions on various nutrition topics.',
+    icon: Users,
+  },
+]
+
+export default function WorkWithMeSection() {
+  return (
+    <section className="work-with-me">
+      <h2>Work With Me</h2>
+      <div className="grid">
+        {services.map((service) => (
+          <div className="box" key={service.id}>
+            <service.icon className="icon" />
+            <h3>{service.name}</h3>
+            <p>{service.description}</p>
+            <Link href={`/contact?service=${encodeURIComponent(service.name)}`} className="cta">
+              Get Started
+            </Link>
+          </div>
+        ))}
+      </div>
+      <style jsx>{`
+        .work-with-me {
+          padding: 3rem 1rem;
+          text-align: center;
+        }
+        .grid {
+          display: grid;
+          gap: 2rem;
+          grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+          margin-top: 2rem;
+        }
+        .box {
+          background: #fff;
+          padding: 2rem;
+          border-radius: 0.5rem;
+          box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+        }
+        .icon {
+          width: 3rem;
+          height: 3rem;
+          margin-bottom: 1rem;
+          color: var(--accent-terra);
+        }
+        .box h3 {
+          margin: 0 0 0.5rem;
+        }
+        .box p {
+          flex-grow: 1;
+          margin-bottom: 1rem;
+        }
+        .cta {
+          background: var(--accent-orange);
+          color: #fff;
+          padding: 0.5rem 1rem;
+          border-radius: 0.25rem;
+          text-decoration: none;
+          transition: background-color 150ms;
+        }
+        .cta:hover {
+          background: var(--accent-olive);
+        }
+      `}</style>
+    </section>
+  )
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,99 +2,101 @@ import Layout from "../components/Layout";
 import BasicMeta from "../components/meta/BasicMeta";
 import OpenGraphMeta from "../components/meta/OpenGraphMeta";
 import TwitterCardMeta from "../components/meta/TwitterCardMeta";
-import { SocialList } from "../components/SocialList";
 import TestimonialSlider from "../components/TestimonialSlider";
+import WorkWithMeSection from "../components/WorkWithMeSection";
+import ContactForm from "../components/ContactForm";
 import Link from "next/link";
-import { GetStaticProps } from "next";
-import { fetchPostContent, PostContent } from "../lib/posts";
 
-type Props = {
-  recentPosts: Pick<PostContent, "title" | "slug">[];
-};
 
-export const getStaticProps: GetStaticProps<Props> = async () => {
-  const allPosts = fetchPostContent();
-  const recentPosts = allPosts.slice(0, 3).map(({ title, slug }) => ({ title, slug }));
-  return {
-    props: {
-      recentPosts,
-    },
-  };
-};
 
-export default function Index({ recentPosts }: Props) {
+export default function Index() {
   return (
-    <Layout>
+    <Layout showBreadcrumb={false}>
       <BasicMeta url={"/"} />
       <OpenGraphMeta url={"/"} />
       <TwitterCardMeta url={"/"} />
-      <div className="container">
-        <div>
+
+      <section className="hero">
+        <div className="overlay">
           <h1>
             Hi, We're Jemma's Nutritional Coaching<span className="fancy">.</span>
           </h1>
           <span className="handle">@jemmasnutritionalcoaching</span>
           <h2>Coaching for a healthy life.</h2>
-
-          <section className="recent">
-            <h3>Recent Posts</h3>
-            <ul>
-              {recentPosts.map((post) => (
-                <li key={post.slug}>
-                  <Link href={`/posts/${post.slug}`}>{post.title}</Link>
-                </li>
-              ))}
-            </ul>
-          </section>
-
-          <TestimonialSlider />
-
-          {/*<SocialList /> - Commented to prevent displaying in main page*/}
+          <Link href="/services" className="explore">
+            Explore Our Services
+          </Link>
         </div>
-      </div>
+      </section>
+
+      <section className="testimonials">
+        <h2>What Our Clients Say</h2>
+        <TestimonialSlider />
+      </section>
+
+      <WorkWithMeSection />
+
+      <section className="contact">
+        <ContactForm />
+      </section>
 
       <style jsx>{`
-        .container {
+        .hero {
+          background: url('/images/hero-image.jpg') center/cover no-repeat;
+          min-height: 60vh;
           display: flex;
           align-items: center;
           justify-content: center;
-          flex: 1 1 auto;
-          padding: 0 1.5rem;
+          text-align: center;
         }
-        h1 {
+        .overlay h1 {
           font-size: 2.5rem;
           margin: 0;
           font-weight: 500;
         }
-        h2 {
+        .overlay h2 {
           font-size: 1.75rem;
           font-weight: 400;
           line-height: 1.25;
+          margin-bottom: 1rem;
         }
         .fancy {
           color: #15847d;
         }
         .handle {
-          display: inline-block;
+          display: block;
           margin-top: 0.275em;
           color: #9b9b9b;
           letter-spacing: 0.05em;
         }
-        .nav {
-          margin: 1rem 0;
-        }
-        .recent h3 {
+        .explore {
+          display: inline-block;
           margin-top: 1rem;
+          background: var(--accent-orange);
+          color: #fff;
+          padding: 0.75rem 1.5rem;
+          border-radius: 0.25rem;
+          text-decoration: none;
+          transition: background-color 150ms;
         }
-        .recent ul {
-          list-style: disc;
-          padding-left: 1.5rem;
+        .explore:hover {
+          background: var(--accent-olive);
+        }
+        .testimonials {
+          padding: 3rem 1rem;
+          text-align: center;
+        }
+        .testimonials h2 {
+          margin-bottom: 2rem;
+        }
+        .contact {
+          padding: 3rem 1rem;
         }
         @media (min-width: 769px) {
-          h1 {
+          .overlay h1 {
             font-size: 3rem;
           }
-          h2 {
+          .overlay h2 {
             font-size: 2.25rem;
           }
         }


### PR DESCRIPTION
## Summary
- add a hero section and CTA on the homepage
- wrap testimonials with heading
- create `WorkWithMeSection` for service boxes
- update contact form to pass service name
- arrange sections vertically and hide breadcrumbs on home

## Testing
- `npx jest` *(fails: 403 Forbidden when fetching packages)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844605d16c88330858032cfc926a471